### PR TITLE
Add contract-level slug tests to lock down edge-case behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,5 +337,5 @@ export const toContentSlug = (string: string): string => {
   let result = unaccentize(string.toLowerCase().trim().replaceAll('_', ' '))
   result = result.replace(stopWordsPattern, '')
 
-  return convert(result).slice(0, 150)
+  return convert(result).slice(0, 150).replace(/-+$/g, '')
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -26,5 +26,23 @@ describe('should convert stuff', () => {
     const longInput = Array.from({ length: 200 }, () => 'word').join(' ')
     const result = toContentSlug(longInput)
     expect(result.length).toBeLessThanOrEqual(150)
+    expect(result).not.toMatch(/-$/)
+  })
+
+  it('returns an empty slug when the input only contains stop words', () => {
+    expect(toContentSlug('le et de ou à')).toBe('')
+  })
+
+  it('normalizes repeated punctuation and underscores', () => {
+    expect(toContentSlug('Bonjour!!!___test??')).toBe('bonjour-test')
+  })
+
+  it('keeps an already normalized slug stable', () => {
+    expect(toContentSlug('deja-vu-bonjour')).toBe('deja-vu-bonjour')
+  })
+
+  it('drops unsupported non latin content instead of throwing', () => {
+    expect(toContentSlug('🍕 Café 東京')).toBe('cafe')
+    expect(toContentSlug('مرحبا بالعالم')).toBe('')
   })
 })


### PR DESCRIPTION
The test suite now explicitly covers inputs:
- made only of stop words,
- repeated punctuation and underscores,
- already-normalized slugs,
- unsupported non-Latin content,
- and the 150-character truncation rule.

While adding those cases, I found that truncation could leave a trailing `-`, so `toContentSlug` now trims trailing hyphens after slicing to keep the final slug clean.